### PR TITLE
Fix bug around getNotificationFeedStats

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'getstream:stream-meteor',
+  name: 'benmgreene:stream-meteor',
   version: '0.4.0',
   summary: 'Getstream.io integration package for Meteor',
-  git: 'https://github.com/GetStream/stream-meteor',
+  git: 'https://github.com/benmgreene/stream-meteor',
   documentation: 'README.md',
 });
 
@@ -39,7 +39,7 @@ Package.onTest(function(api) {
   api.use(['underscore', 'mongo']);
   api.use('insecure');
   api.use('accounts-base');
-  api.use('getstream:stream-meteor');
+  api.use('benmgreene:stream-meteor');
 
   api.addFiles('test/spec.js');
   api.addFiles('test/client/spec.js', ['client']);

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'getstream:stream-meteor',
   version: '0.4.0',
   summary: 'Getstream.io integration package for Meteor',
-  git: 'https://github.com/getstream/stream-meteor',
+  git: 'https://github.com/GetStream/stream-meteor',
   documentation: 'README.md',
 });
 

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'benmgreene:stream-meteor',
+  name: 'GetStream:stream-meteor',
   version: '0.4.0',
   summary: 'Getstream.io integration package for Meteor',
-  git: 'https://github.com/benmgreene/stream-meteor',
+  git: 'https://github.com/GetStream/stream-meteor',
   documentation: 'README.md',
 });
 
@@ -39,7 +39,7 @@ Package.onTest(function(api) {
   api.use(['underscore', 'mongo']);
   api.use('insecure');
   api.use('accounts-base');
-  api.use('benmgreene:stream-meteor');
+  api.use('GetStream:stream-meteor');
 
   api.addFiles('test/spec.js');
   api.addFiles('test/client/spec.js', ['client']);

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'GetStream:stream-meteor',
+  name: 'getstream:stream-meteor',
   version: '0.4.0',
   summary: 'Getstream.io integration package for Meteor',
-  git: 'https://github.com/GetStream/stream-meteor',
+  git: 'https://github.com/getstream/stream-meteor',
   documentation: 'README.md',
 });
 
@@ -39,7 +39,7 @@ Package.onTest(function(api) {
   api.use(['underscore', 'mongo']);
   api.use('insecure');
   api.use('accounts-base');
-  api.use('GetStream:stream-meteor');
+  api.use('getstream:stream-meteor');
 
   api.addFiles('test/spec.js');
   api.addFiles('test/client/spec.js', ['client']);

--- a/src/server/publish.js
+++ b/src/server/publish.js
@@ -19,8 +19,7 @@ function streamSubscriptionHandleFactory(name, collectReferences, publication, s
 
 		if ((data.unread != null) && (data.unseen != null)) {
 			let notification = Stream.notifications.findOne({ feedGroup: streamFeed.slug, feedId: streamFeed.userId });
-			// console.log("!!! notification", notification);
-			// console.log("!!! publication", publication);
+
 			if (notification) {
 				publication.changed('Stream.notifications', notification._id, { unread: data.unread, unseen: data.unseen });
 			}

--- a/src/server/publish.js
+++ b/src/server/publish.js
@@ -17,9 +17,10 @@ function streamSubscriptionHandleFactory(name, collectReferences, publication, s
 
 		_(data.deleted).each(activityId => publication.removed(name, activityId));
 
-		if (data.unread && data.unseen) {
+		if ((data.unread != null) && (data.unseen != null)) {
 			let notification = Stream.notifications.findOne({ feedGroup: streamFeed.slug, feedId: streamFeed.userId });
-
+			// console.log("!!! notification", notification);
+			// console.log("!!! publication", publication);
 			if (notification) {
 				publication.changed('Stream.notifications', notification._id, { unread: data.unread, unseen: data.unseen });
 			}
@@ -58,13 +59,13 @@ function publish(name, getFeed, collectReferences, getParams={}) {
 		var feedSelector = { feedGroup: streamFeed.slug, feedId: streamFeed.userId }
 		  , dbFeed = Stream.notifications.findOne(feedSelector);
 
-		if (! dbFeed && feed.unread && feed.unseen) {
+		if (! dbFeed && (feed.unread != null) && (feed.unseen != null)) {
 			Stream.notifications.insert(_(feedSelector).extend({ unread: feed.unread, unseen: feed.unseen }));
-		} else if(feed.unread && feed.unseen) {
+		} else if((feed.unread != null) && (feed.unseen != null)) {
 			Stream.notifications.update(dbFeed._id, { $set: { unread: feed.unread, unseen: feed.unseen }});
 		}
 
-		if (feed.unread && feed.unseen) {
+		if ((feed.unread != null) && (feed.unseen != null)) {
 			cursors.push(Stream.notifications.find(feedSelector));
 		}
 


### PR DESCRIPTION
The code uses the existence of `unread` and `unseen` as a proxy for whether the feed is a **notification** feed, but when `unread` or `unseen` was equal to zero, stats would not be available on client and could cause error on server.
