### PR TITLE
Changed publication to check for field limiters

### DIFF
--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,604 @@
+{
+  "dependencies": {
+    "fibers": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-1.0.8.tgz",
+      "from": "fibers@1.0.8"
+    },
+    "getstream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/getstream/-/getstream-3.2.0.tgz",
+      "from": "getstream@3.2.0",
+      "dependencies": {
+        "Base64": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz",
+          "from": "Base64@>=0.3.0 <0.4.0"
+        },
+        "faye": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/faye/-/faye-1.1.2.tgz",
+          "from": "faye@>=1.1.2 <2.0.0",
+          "dependencies": {
+            "csprng": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/csprng/-/csprng-0.1.1.tgz",
+              "from": "csprng@latest",
+              "dependencies": {
+                "sequin": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/sequin/-/sequin-0.1.0.tgz",
+                  "from": "sequin@latest"
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
+              "from": "faye-websocket@>=0.9.1",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.4",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+                  "from": "websocket-driver@>=0.5.1",
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                      "from": "websocket-extensions@>=0.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+              "from": "tough-cookie@latest"
+            },
+            "tunnel-agent": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0"
+            }
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "from": "http-signature@>=1.0.2 <2.0.0",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "from": "assert-plus@>=0.2.0 <0.3.0"
+            },
+            "jsprim": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+              "from": "jsprim@>=1.2.2 <2.0.0",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                  "from": "extsprintf@1.0.2"
+                },
+                "json-schema": {
+                  "version": "0.2.2",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                  "from": "json-schema@0.2.2"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                  "from": "verror@1.3.6"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.8.1",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.1.tgz",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.2.3",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                  "from": "asn1@>=0.2.3 <0.3.0"
+                },
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "from": "assert-plus@>=1.0.0 <2.0.0"
+                },
+                "dashdash": {
+                  "version": "1.13.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+                  "from": "dashdash@>=1.12.0 <2.0.0"
+                },
+                "getpass": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.5.tgz",
+                  "from": "getpass@>=0.1.1 <0.2.0"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                  "from": "jodid25519@>=1.0.0 <2.0.0"
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                  "from": "jsbn@>=0.1.0 <0.2.0"
+                },
+                "tweetnacl": {
+                  "version": "0.13.3",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                  "from": "tweetnacl@>=0.13.0 <0.14.0"
+                }
+              }
+            }
+          }
+        },
+        "jsonwebtoken": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
+          "from": "jsonwebtoken@>=5.0.1 <6.0.0",
+          "dependencies": {
+            "jws": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
+              "from": "jws@>=3.0.0 <4.0.0",
+              "dependencies": {
+                "base64url": {
+                  "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+                  "from": "base64url@>=1.0.4 <1.1.0",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.4.10",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                      "from": "concat-stream@>=1.4.7 <1.5.0",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.14",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "from": "core-util-is@>=1.0.0 <1.1.0"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "from": "string_decoder@>=0.10.0 <0.11.0"
+                            }
+                          }
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                          "from": "typedarray@>=0.0.5 <0.1.0"
+                        }
+                      }
+                    },
+                    "meow": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                      "from": "meow@>=2.0.0 <2.1.0",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                              "from": "camelcase@>=1.0.1 <2.0.0"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                              "from": "map-obj@>=1.0.0 <2.0.0"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                          "from": "indent-string@>=1.1.0 <2.0.0",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                              "from": "get-stdin@>=4.0.1 <5.0.0"
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "from": "repeating@>=1.1.0 <2.0.0",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                          "from": "minimist@>=1.1.0 <2.0.0"
+                        },
+                        "object-assign": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                          "from": "object-assign@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "jwa": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
+                  "from": "jwa@>=1.1.2 <2.0.0",
+                  "dependencies": {
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+                      "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0"
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
+                      "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
+                      "dependencies": {
+                        "base64-url": {
+                          "version": "1.2.2",
+                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz",
+                          "from": "base64-url@>=1.2.1 <2.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@>=0.7.1 <0.8.0"
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "from": "xtend@>=4.0.1 <5.0.0"
+            }
+          }
+        },
+        "qs": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
+          "from": "qs@>=6.0.1 <7.0.0"
+        },
+        "request": {
+          "version": "2.67.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+          "from": "request@2.67.0",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "from": "aws-sign2@>=0.6.0 <0.7.0"
+            },
+            "bl": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+              "from": "bl@>=1.0.0 <1.1.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "from": "isarray@>=1.0.0 <1.1.0"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "from": "caseless@>=0.11.0 <0.12.0"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "from": "extend@>=3.0.0 <3.1.0"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "from": "forever-agent@>=0.6.1 <0.7.0"
+            },
+            "form-data": {
+              "version": "1.0.0-rc4",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "from": "async@>=1.5.2 <2.0.0"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "from": "har-validator@>=2.0.2 <2.1.0",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "from": "supports-color@>=2.0.0 <3.0.0"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "from": "commander@>=2.9.0 <3.0.0",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "from": "generate-function@>=2.0.0 <3.0.0"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "from": "is-property@>=1.0.0 <2.0.0"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "from": "jsonpointer@2.0.0"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "from": "xtend@>=4.0.0 <5.0.0"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "from": "pinkie@>=2.0.0 <3.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "from": "hawk@>=3.1.0 <3.2.0",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "from": "boom@>=2.0.0 <3.0.0"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "from": "cryptiles@>=2.0.0 <3.0.0"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "from": "hoek@>=2.0.0 <3.0.0"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "from": "sntp@>=1.0.0 <2.0.0"
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "from": "is-typedarray@>=1.0.0 <1.1.0"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.2 <0.2.0"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0"
+            },
+            "mime-types": {
+              "version": "2.1.10",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                  "from": "mime-db@>=1.22.0 <1.23.0"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "from": "node-uuid@>=1.4.7 <1.5.0"
+            },
+            "oauth-sign": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
+              "from": "oauth-sign@>=0.8.0 <0.9.0"
+            },
+            "qs": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+              "from": "qs@>=5.2.0 <5.3.0"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "from": "stringstream@>=0.0.4 <0.1.0"
+            },
+            "tough-cookie": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+              "from": "tough-cookie@latest"
+            },
+            "tunnel-agent": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0"
+            }
+          }
+        },
+        "xmlhttp-request": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/xmlhttp-request/-/xmlhttp-request-0.4.0.tgz",
+          "from": "xmlhttp-request@>=0.4.0 <0.5.0"
+        }
+      }
+    }
+  }
+}

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -3,49 +3,49 @@
     "fibers": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-1.0.8.tgz",
-      "from": "fibers@1.0.8"
+      "from": "https://registry.npmjs.org/fibers/-/fibers-1.0.8.tgz"
     },
     "getstream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/getstream/-/getstream-3.2.0.tgz",
-      "from": "getstream@3.2.0",
+      "from": "https://registry.npmjs.org/getstream/-/getstream-3.2.0.tgz",
       "dependencies": {
         "Base64": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz",
-          "from": "Base64@>=0.3.0 <0.4.0"
+          "from": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz"
         },
         "faye": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/faye/-/faye-1.1.2.tgz",
-          "from": "faye@>=1.1.2 <2.0.0",
+          "from": "https://registry.npmjs.org/faye/-/faye-1.1.2.tgz",
           "dependencies": {
             "csprng": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/csprng/-/csprng-0.1.1.tgz",
-              "from": "csprng@latest",
+              "from": "https://registry.npmjs.org/csprng/-/csprng-0.1.1.tgz",
               "dependencies": {
                 "sequin": {
                   "version": "0.1.0",
                   "resolved": "https://registry.npmjs.org/sequin/-/sequin-0.1.0.tgz",
-                  "from": "sequin@latest"
+                  "from": "https://registry.npmjs.org/sequin/-/sequin-0.1.0.tgz"
                 }
               }
             },
             "faye-websocket": {
               "version": "0.11.0",
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
-              "from": "faye-websocket@>=0.9.1",
+              "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz",
               "dependencies": {
                 "websocket-driver": {
                   "version": "0.6.4",
                   "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
-                  "from": "websocket-driver@>=0.5.1",
+                  "from": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
                   "dependencies": {
                     "websocket-extensions": {
                       "version": "0.1.1",
                       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-                      "from": "websocket-extensions@>=0.1.1"
+                      "from": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
                     }
                   }
                 }
@@ -54,86 +54,86 @@
             "tough-cookie": {
               "version": "2.2.2",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-              "from": "tough-cookie@latest"
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0"
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "from": "http-signature@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-              "from": "assert-plus@>=0.2.0 <0.3.0"
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.2.2",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-              "from": "jsprim@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                  "from": "extsprintf@1.0.2"
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.2",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                  "from": "json-schema@0.2.2"
+                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                  "from": "verror@1.3.6"
+                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
               "version": "1.8.1",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.1.tgz",
-              "from": "sshpk@>=1.7.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.1.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                  "from": "asn1@>=0.2.3 <0.3.0"
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "assert-plus": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "from": "assert-plus@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "dashdash": {
                   "version": "1.13.0",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
-                  "from": "dashdash@>=1.12.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz"
                 },
                 "getpass": {
                   "version": "0.1.5",
                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.5.tgz",
-                  "from": "getpass@>=0.1.1 <0.2.0"
+                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.5.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                  "from": "jodid25519@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.0",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                  "from": "jsbn@>=0.1.0 <0.2.0"
+                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.13.3",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                  "from": "tweetnacl@>=0.13.0 <0.14.0"
+                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                 }
               }
             }
@@ -142,103 +142,103 @@
         "jsonwebtoken": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
-          "from": "jsonwebtoken@>=5.0.1 <6.0.0",
+          "from": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
           "dependencies": {
             "jws": {
               "version": "3.1.3",
               "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
-              "from": "jws@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
               "dependencies": {
                 "base64url": {
                   "version": "1.0.6",
                   "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
-                  "from": "base64url@>=1.0.4 <1.1.0",
+                  "from": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.4.10",
                       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-                      "from": "concat-stream@>=1.4.7 <1.5.0",
+                      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "from": "inherits@>=2.0.1 <2.1.0"
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "readable-stream": {
                           "version": "1.1.14",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "from": "core-util-is@>=1.0.0 <1.1.0"
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                              "from": "isarray@0.0.1"
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "from": "string_decoder@>=0.10.0 <0.11.0"
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             }
                           }
                         },
                         "typedarray": {
                           "version": "0.0.6",
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                          "from": "typedarray@>=0.0.5 <0.1.0"
+                          "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         }
                       }
                     },
                     "meow": {
                       "version": "2.0.0",
                       "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-                      "from": "meow@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                           "dependencies": {
                             "camelcase": {
                               "version": "1.2.1",
                               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                              "from": "camelcase@>=1.0.1 <2.0.0"
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                             },
                             "map-obj": {
                               "version": "1.0.1",
                               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                              "from": "map-obj@>=1.0.0 <2.0.0"
+                              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                             }
                           }
                         },
                         "indent-string": {
                           "version": "1.2.2",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-                          "from": "indent-string@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                           "dependencies": {
                             "get-stdin": {
                               "version": "4.0.1",
                               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                              "from": "get-stdin@>=4.0.1 <5.0.0"
+                              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                             },
                             "repeating": {
                               "version": "1.1.3",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                              "from": "repeating@>=1.1.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
                                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0"
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
                                 }
@@ -249,12 +249,12 @@
                         "minimist": {
                           "version": "1.2.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                          "from": "minimist@>=1.1.0 <2.0.0"
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
                         "object-assign": {
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-                          "from": "object-assign@>=1.0.0 <2.0.0"
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz"
                         }
                       }
                     }
@@ -263,22 +263,22 @@
                 "jwa": {
                   "version": "1.1.3",
                   "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
-                  "from": "jwa@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
                   "dependencies": {
                     "buffer-equal-constant-time": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-                      "from": "buffer-equal-constant-time@>=1.0.1 <2.0.0"
+                      "from": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
                     },
                     "ecdsa-sig-formatter": {
                       "version": "1.0.5",
                       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
-                      "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz",
                       "dependencies": {
                         "base64-url": {
                           "version": "1.2.2",
                           "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz",
-                          "from": "base64-url@>=1.2.1 <2.0.0"
+                          "from": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz"
                         }
                       }
                     }
@@ -289,69 +289,69 @@
             "ms": {
               "version": "0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "from": "ms@>=0.7.1 <0.8.0"
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "xtend": {
               "version": "4.0.1",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "from": "xtend@>=4.0.1 <5.0.0"
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "qs": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
-          "from": "qs@>=6.0.1 <7.0.0"
+          "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
         },
         "request": {
           "version": "2.67.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-          "from": "request@2.67.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "from": "aws-sign2@>=0.6.0 <0.7.0"
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "bl": {
               "version": "1.0.3",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-              "from": "bl@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "from": "core-util-is@>=1.0.0 <1.1.0"
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "from": "inherits@>=2.0.1 <2.1.0"
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "from": "isarray@>=1.0.0 <1.1.0"
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "from": "string_decoder@>=0.10.0 <0.11.0"
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0"
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -360,148 +360,148 @@
             "caseless": {
               "version": "0.11.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "from": "caseless@>=0.11.0 <0.12.0"
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0"
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "from": "extend@>=3.0.0 <3.1.0"
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "from": "forever-agent@>=0.6.1 <0.7.0"
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc4",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "from": "async@>=1.5.2 <2.0.0"
+                  "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "from": "har-validator@>=2.0.2 <2.1.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0"
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0"
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0"
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0"
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "from": "supports-color@>=2.0.0 <3.0.0"
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "from": "commander@>=2.9.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "from": "graceful-readlink@>=1.0.0"
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.13.1",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "from": "generate-function@>=2.0.0 <3.0.0"
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "from": "is-property@>=1.0.0 <2.0.0"
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "from": "jsonpointer@2.0.0"
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "from": "xtend@>=4.0.0 <5.0.0"
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "from": "pinkie@>=2.0.0 <3.0.0"
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
@@ -510,93 +510,93 @@
             "hawk": {
               "version": "3.1.3",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "from": "hawk@>=3.1.0 <3.2.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "from": "boom@>=2.0.0 <3.0.0"
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "from": "cryptiles@>=2.0.0 <3.0.0"
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "hoek": {
                   "version": "2.16.3",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "from": "hoek@>=2.0.0 <3.0.0"
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "from": "sntp@>=1.0.0 <2.0.0"
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "is-typedarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "from": "is-typedarray@>=1.0.0 <1.1.0"
+              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "from": "isstream@>=0.1.2 <0.2.0"
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0"
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.10",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
-              "from": "mime-types@>=2.1.7 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
-                  "from": "mime-db@>=1.22.0 <1.23.0"
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "from": "node-uuid@>=1.4.7 <1.5.0"
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.1",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
-              "from": "oauth-sign@>=0.8.0 <0.9.0"
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
             },
             "qs": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "from": "qs@>=5.2.0 <5.3.0"
+              "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "from": "stringstream@>=0.0.4 <0.1.0"
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.2.2",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-              "from": "tough-cookie@latest"
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0"
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
         },
         "xmlhttp-request": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/xmlhttp-request/-/xmlhttp-request-0.4.0.tgz",
-          "from": "xmlhttp-request@>=0.4.0 <0.5.0"
+          "from": "https://registry.npmjs.org/xmlhttp-request/-/xmlhttp-request-0.4.0.tgz"
         }
       }
     }

--- a/src/collections.js
+++ b/src/collections.js
@@ -48,6 +48,10 @@ Stream.registerActivity = function(collection, activityDocProps) {
   return collection;
 };
 
+Stream.setPublishFields = function(publishFields) {
+  Stream.publishFields = publishFields;
+}
+
 Stream.feeds = {};
 
 var feeds = _(Stream._settings.newsFeeds).pairs();

--- a/src/collections.js
+++ b/src/collections.js
@@ -48,10 +48,6 @@ Stream.registerActivity = function(collection, activityDocProps) {
   return collection;
 };
 
-Stream.setPublishFields = function(publishFields) {
-  Stream.publishFields = publishFields;
-}
-
 Stream.feeds = {};
 
 var feeds = _(Stream._settings.newsFeeds).pairs();

--- a/src/server/publish.js
+++ b/src/server/publish.js
@@ -80,8 +80,10 @@ function publish(name, getFeed, collectReferences, getParams={}) {
 			if(! collection instanceof Mongo.Collection) {
 		        throw new Meteor.Error('non-collection', `couldn\'t find collection with name ${ref}`);
 			}
-
-			cursors.push(collection.find({ _id: { $in: ids } }));
+			if (Stream.publishFields && Stream.publishFields[model])
+				cursors.push(collection.find({ _id: { $in: ids } }, { fields: Stream.publishFields[model] }));
+			else
+				cursors.push(collection.find({ _id: { $in: ids } }));
 		});
 
 		var streamSubscriptionHandle = streamSubscriptionHandleFactory(name, collectReferences, publication, streamFeed);
@@ -124,8 +126,6 @@ _(Stream._settings.newsFeeds).each((feedType, feedGroup) => {
 		collect = aggregatedCollectReferences;
 	}
 
-	publish(`Stream.feeds.${feedGroup}`, _.partial(getNewsFeed, feedGroup), collect);	
 });
 
 publish('Stream.feeds.notification', getNotificationFeed, aggregatedCollectReferences);
-publish('Stream.feeds.user', getUserFeed, Stream.backend.collectReferences.bind(Stream.backend));

--- a/src/server/publish.js
+++ b/src/server/publish.js
@@ -30,6 +30,10 @@ function streamSubscriptionHandleFactory(name, collectReferences, publication, s
 
 }
 
+Stream.setPublishFields = function(publishFields) {
+  Stream.publishFields = publishFields;
+}
+
 function publish(name, getFeed, collectReferences, getParams={}) {
 	Meteor.publish(name, function(limit=20, userId=undefined /* subscribe params */) {
 		var publication = this;
@@ -126,6 +130,8 @@ _(Stream._settings.newsFeeds).each((feedType, feedGroup) => {
 		collect = aggregatedCollectReferences;
 	}
 
+	publish(`Stream.feeds.${feedGroup}`, _.partial(getNewsFeed, feedGroup), collect);
 });
 
 publish('Stream.feeds.notification', getNotificationFeed, aggregatedCollectReferences);
+publish('Stream.feeds.user', getUserFeed, Stream.backend.collectReferences.bind(Stream.backend));


### PR DESCRIPTION
When enriching activities, the publication now checked for a object called Stream.publishFields, which is defined on the Server. The object contains a list of whitelisted fields to publish on the cursor. If this object or the model within the object does not exist, all fields are published.

Example usecase would be:

Stream.publishFields = {
  users: {
    profile: 1,
  }
}
